### PR TITLE
Deployment fixes

### DIFF
--- a/configuration/aai-mock/application.properties
+++ b/configuration/aai-mock/application.properties
@@ -1,5 +1,5 @@
-main.oidc.issuer.url=http://localhost:8080/oidc/
-web.baseURL=https://localhost:8080/oidc
+main.oidc.issuer.url=http://${DOCKERHOST}:8080/oidc/
+web.baseURL=https://${DOCKERHOST}:8080/oidc
 
 # GA4GH broker
 ga4gh.broker.url=http://aai-mock:8080/ga4gh-broker/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,8 @@
 version: '3'
 services:
   aai-mock:
+    environment:
+      - DOCKERHOST=${DOCKERHOST:-localhost}
     extra_hosts:
       - "${DOCKERHOST:-dockerhost}:host-gateway"
     image: registry.gitlab.ics.muni.cz:443/perun/deployment/proxyidp/proxyidp-public-docker-images/ls_aai_mock:2.5.2-broker2.1.10-tomcat9.0-jdk11

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,8 @@
 version: '3'
 services:
   aai-mock:
+    extra_hosts:
+      - "${DOCKERHOST:-dockerhost}:host-gateway"
     image: registry.gitlab.ics.muni.cz:443/perun/deployment/proxyidp/proxyidp-public-docker-images/ls_aai_mock:2.5.2-broker2.1.10-tomcat9.0-jdk11
     container_name: ls-aai-mock
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
     volumes:
       - "./scripts/aai-mock.sql:/docker-entrypoint-initdb.d/1.sql"
     # remove this to disable persistent storage
-      - "./mysql://var/lib/mysql"
+      - "mysql:/var/lib/mysql"
     ports:
       - '3306:3306'
     networks:
@@ -53,3 +53,6 @@ networks:
   lsaaimock:
   my-app-network:
     external: true
+
+volumes:
+  mysql:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,7 +52,7 @@ services:
 networks:
   lsaaimock:
   my-app-network:
-    external: true
+    name: my-app-network
 
 volumes:
   mysql:


### PR DESCRIPTION
This PR is aimed to simplify testing of selective components in the starter-kit.
* disconnects `ls-aai-mock` from `storage-and-interfaces` by defining `my-app-network` in this compose file. This allows testing of for example aai-mock and REMS without the need to start storage-and-interfaces as well.
* binds host-gateway as an extra host so container  to container communication can be performed as if from a local shell.
* writes mysql data to a docker volume instead of to local path in order to simplify cleanup without the need to use escalated privileges.